### PR TITLE
Change StyledComponent to use React.PureComponent

### DIFF
--- a/src/connectStyle.js
+++ b/src/connectStyle.js
@@ -112,7 +112,7 @@ export default (
       );
     }
 
-    class StyledComponent extends React.Component {
+    class StyledComponent extends React.PureComponent {
       static contextTypes = {
         theme: ThemeShape,
         // The style inherited from the parent


### PR DESCRIPTION
even with `shouldRebuildStyle` there are still avoidable rerenders that can be removed by using React.PureComponent, especially since rerenders are so expensive in react-native